### PR TITLE
Battery level feature

### DIFF
--- a/ATC_Thermometer/app.c
+++ b/ATC_Thermometer/app.c
@@ -85,21 +85,20 @@ void main_loop(){
 		}
 		
 		
-		if(!show_batt_enabled){
-			show_batt_or_humi = true;
+		if(!show_batt_enabled) show_batt_or_humi = true;
+		
+		if(show_batt_or_humi){//Change between Humidity displaying and battery level if show_batt_enabled=true
+			show_small_number(humi,1);	
 			if(battery_level <= 15) {
 			    show_battery_symbol(1);
 			}else{
-			    show_battery_symbol(0);
+			    show_battery_symbol(0);   
 			}
-		}
-		if(show_batt_or_humi){//Change between Humidity displaying and battery level
-			show_small_number(humi,1);	
-			show_battery_symbol(0);
 		}else{
 			show_small_number((battery_level==100)?99:battery_level,1);
 			show_battery_symbol(1);
 		}
+
 		show_batt_or_humi = !show_batt_or_humi;
 		
 		if(ble_get_connected()){//If connected notify Sensor data

--- a/ATC_Thermometer/app.c
+++ b/ATC_Thermometer/app.c
@@ -18,8 +18,8 @@ RAM bool show_batt_or_humi;
 RAM bool temp_C_or_F;
 RAM bool blinking_smiley = false;
 RAM bool comfort_smiley = true;
-RAM bool show_batt_enabled = true;
-RAM bool advertising_type = false;//Custom or Mi Advertising
+RAM bool show_batt_enabled = false;
+RAM bool advertising_type = false;//Custom or Mi Advertising (true)
 RAM uint8_t advertising_interval = 6;//multiply by 10 for value
 RAM int8_t temp_offset;
 RAM int8_t humi_offset;
@@ -85,7 +85,14 @@ void main_loop(){
 		}
 		
 		
-		if(!show_batt_enabled)show_batt_or_humi = true;
+		if(!show_batt_enabled){
+			show_batt_or_humi = true;
+			if(battery_level <= 15) {
+			    show_battery_symbol(1);
+			}else{
+			    show_battery_symbol(0);
+			}
+		}
 		if(show_batt_or_humi){//Change between Humidity displaying and battery level
 			show_small_number(humi,1);	
 			show_battery_symbol(0);

--- a/ATC_Thermometer/battery.c
+++ b/ATC_Thermometer/battery.c
@@ -77,6 +77,6 @@ return batt_vol_mv;
 uint8_t get_battery_level(uint16_t battery_mv){
 	uint8_t battery_level = (battery_mv-2200)/(31-22);
 	if(battery_level>100)battery_level=100;
-	if(battery_level<0)battery_level=0;
+	if(battery_mv<2200)battery_level=0;
 	return battery_level;
 }


### PR DESCRIPTION
New:
- if show_batt_enabled=false - no switching value on display (new default) will be shown the battery symbol if battery level is <15%

I have tested 3 such sensors and it seems to be a good value for this.

- in battery.c was changed the issue that for voltage value <2200 will be given 100% ;)
(uint8_t of negative value...)