### PR TITLE
Measure delay

### DIFF
--- a/ATC_Thermometer/app.c
+++ b/ATC_Thermometer/app.c
@@ -23,7 +23,7 @@ RAM bool comfort_smiley = true;
 RAM bool show_batt_enabled = true;
 RAM bool advertising_type = false;//Custom or Mi Advertising (true)
 RAM uint8_t advertising_interval = 6;//advise new values - multiply by 10 for value
-RAM uint8_t measure_interval = 25;//time = sensor advertising interval * factor (def: 2s * X)
+RAM uint8_t measure_interval = 10;//time = loop interval * factor (def: about 7 * X)
 RAM int8_t temp_offset;
 RAM int8_t humi_offset;
 RAM uint8_t temp_alarm_point = 5;//divide by ten for value

--- a/ATC_Thermometer/app.c
+++ b/ATC_Thermometer/app.c
@@ -8,6 +8,7 @@ RAM uint32_t last_delay = 0xFFFF0000, last_adv_delay = 0xFFFF0000, last_battery_
 RAM bool last_smiley;
 int16_t temp = 0;
 uint16_t humi = 0;
+AM uint8_t adv_count = 0;
 RAM int16_t last_temp;
 RAM uint16_t last_humi;
 RAM uint8_t battery_level;
@@ -107,9 +108,13 @@ void main_loop(){
 			ble_send_battery(battery_level);
 		}
 		
-		if((clock_time()-last_adv_delay) > advertising_interval*(advertising_type?5000:10000)*CLOCK_SYS_CLOCK_1MS){//Advetise data delay
+		if((clock_time() - last_adv_delay) > (advertising_type?5000:10000)*CLOCK_SYS_CLOCK_1MS){//Advetise data delay
+		    if(adv_count >= advertising_interval){
 			set_adv_data(temp, humi, battery_level, battery_mv);
 			last_adv_delay = clock_time();
+			adv_count=0;
+		    }
+		    adv_count++;
 		}else if((temp-last_temp > temp_alarm_point)||(last_temp-temp > temp_alarm_point)||(humi-last_humi > humi_alarm_point)||(last_humi-humi > humi_alarm_point)){// instant advertise on to much sensor difference
 			set_adv_data(temp, humi, battery_level, battery_mv);
 		}

--- a/ATC_Thermometer/app.c
+++ b/ATC_Thermometer/app.c
@@ -85,21 +85,20 @@ void main_loop(){
 		}
 		
 		
-		if(!show_batt_enabled){
-			show_batt_or_humi = true;
+		if(!show_batt_enabled) show_batt_or_humi = true;
+		
+		if(show_batt_or_humi){//Change between Humidity displaying and battery level if show_batt_enabled=true
+			show_small_number(humi,1);	
 			if(battery_level <= 15) {
 			    show_battery_symbol(1);
 			}else{
-			    show_battery_symbol(0);
+			    show_battery_symbol(0);   
 			}
-		}
-		if(show_batt_or_humi){//Change between Humidity displaying and battery level
-			show_small_number(humi,1);	
-			show_battery_symbol(0);
 		}else{
 			show_small_number((battery_level==100)?99:battery_level,1);
 			show_battery_symbol(1);
 		}
+
 		show_batt_or_humi = !show_batt_or_humi;
 		
 		if(ble_get_connected()){//If connected notify Sensor data

--- a/ATC_Thermometer/app.c
+++ b/ATC_Thermometer/app.c
@@ -96,12 +96,6 @@ void main_loop(){
 
 		if(!show_batt_enabled) show_batt_or_humi = true;
 		
-<<<<<<< Updated upstream
-		
-		if(!show_batt_enabled) show_batt_or_humi = true;
-		
-=======
->>>>>>> Stashed changes
 		if(show_batt_or_humi){//Change between Humidity displaying and battery level if show_batt_enabled=true
 			show_small_number(humi,1);	
 			if(battery_level <= 15) {
@@ -113,11 +107,7 @@ void main_loop(){
 			show_small_number((battery_level==100)?99:battery_level,1);
 			show_battery_symbol(1);
 		}
-<<<<<<< Updated upstream
 
-=======
-		
->>>>>>> Stashed changes
 		show_batt_or_humi = !show_batt_or_humi;
 		
 		if(ble_get_connected()){//If connected notify Sensor data

--- a/ATC_Thermometer/app.c
+++ b/ATC_Thermometer/app.c
@@ -8,7 +8,7 @@ RAM uint32_t last_delay = 0xFFFF0000, last_adv_delay = 0xFFFF0000, last_battery_
 RAM bool last_smiley;
 int16_t temp = 0;
 uint16_t humi = 0;
-AM uint8_t adv_count = 0;
+RAM uint8_t adv_count = 0;
 RAM int16_t last_temp;
 RAM uint16_t last_humi;
 RAM uint8_t battery_level;

--- a/ATC_Thermometer/app.c
+++ b/ATC_Thermometer/app.c
@@ -4,8 +4,9 @@
 #include "stack/ble/ble.h"
 #include "vendor/common/blt_common.h"
 
-RAM uint32_t last_delay = 0xFFFF0000, last_adv_delay = 0xFFFF0000, last_battery_delay = 0xFFFF0000;
+RAM uint32_t last_delay = 0xFFFF0000, last_adv_delay = 0xFFFF0000, last_battery_delay = 0xFFFF0000, last_battsym_delay = 0xFFFF0000;
 RAM bool last_smiley;
+RAM bool last_batt;
 int16_t temp = 0;
 uint16_t humi = 0;
 RAM uint8_t adv_count = 0;
@@ -21,11 +22,11 @@ RAM bool blinking_smiley = false;
 RAM bool comfort_smiley = true;
 RAM bool show_batt_enabled = false;
 RAM bool advertising_type = false;//Custom or Mi Advertising (true)
-RAM uint8_t advertising_interval = 6;//multiply by 10 for value
+RAM uint8_t advertising_interval = 20;//multiply by 10 for value
 RAM int8_t temp_offset;
 RAM int8_t humi_offset;
-RAM uint8_t temp_alarm_point = 5;//divide by ten for value
-RAM uint8_t humi_alarm_point = 5;
+RAM uint8_t temp_alarm_point = 50;//divide by ten for value
+RAM uint8_t humi_alarm_point = 50;
 
 RAM int16_t comfort_x[] = {2000, 2560, 2700, 2500, 2050, 1700, 1600, 1750};
 RAM uint16_t comfort_y[] = {2000, 1980, 3200, 6000, 8200, 8600, 7700, 3800};
@@ -65,7 +66,15 @@ _attribute_ram_code_ void user_init_deepRetn(void){//after sleep this will get e
 }
 
 void main_loop(){	
-	if((clock_time()-last_delay) > 5000*CLOCK_SYS_CLOCK_1MS){//main loop delay
+/*	if((clock_time()-last_battsym_delay) > 400*CLOCK_SYS_CLOCK_1MS){  //batt blinking delay
+	    if((battery_level < 25) && (battery_level > 15) && (!show_batt_enabled)) {
+		last_batt=!last_batt;
+		show_battery_symbol(last_batt);
+		update_lcd();
+		last_battsym_delay = clock_time();
+	    }
+	}
+*/	if((clock_time()-last_delay) > 5000*CLOCK_SYS_CLOCK_1MS){//main loop delay
 	
 		if((clock_time()-last_battery_delay) > 5*60000*CLOCK_SYS_CLOCK_1MS){//Read battery delay
 			battery_mv = get_battery_mv();
@@ -84,10 +93,15 @@ void main_loop(){
 			show_temp_symbol(1);
 			show_big_number(temp,1);
 		}
+
+		if(!show_batt_enabled) show_batt_or_humi = true;
 		
+<<<<<<< Updated upstream
 		
 		if(!show_batt_enabled) show_batt_or_humi = true;
 		
+=======
+>>>>>>> Stashed changes
 		if(show_batt_or_humi){//Change between Humidity displaying and battery level if show_batt_enabled=true
 			show_small_number(humi,1);	
 			if(battery_level <= 15) {
@@ -99,7 +113,11 @@ void main_loop(){
 			show_small_number((battery_level==100)?99:battery_level,1);
 			show_battery_symbol(1);
 		}
+<<<<<<< Updated upstream
 
+=======
+		
+>>>>>>> Stashed changes
 		show_batt_or_humi = !show_batt_or_humi;
 		
 		if(ble_get_connected()){//If connected notify Sensor data

--- a/ATC_Thermometer/app.c
+++ b/ATC_Thermometer/app.c
@@ -4,9 +4,8 @@
 #include "stack/ble/ble.h"
 #include "vendor/common/blt_common.h"
 
-RAM uint32_t last_delay = 0xFFFF0000, last_adv_delay = 0xFFFF0000, last_battery_delay = 0xFFFF0000, last_battsym_delay = 0xFFFF0000;
+RAM uint32_t last_delay = 0xFFFF0000, last_adv_delay = 0xFFFF0000, last_battery_delay = 0xFFFF0000;
 RAM bool last_smiley;
-RAM bool last_batt;
 int16_t temp = 0;
 uint16_t humi = 0;
 RAM uint8_t adv_count = 0;
@@ -21,7 +20,7 @@ RAM bool show_batt_or_humi;
 RAM bool temp_C_or_F;
 RAM bool blinking_smiley = false;
 RAM bool comfort_smiley = true;
-RAM bool show_batt_enabled = false;
+RAM bool show_batt_enabled = true;
 RAM bool advertising_type = false;//Custom or Mi Advertising (true)
 RAM uint8_t advertising_interval = 6;//advise new values - multiply by 10 for value
 RAM uint8_t measure_interval = 25;//time = sensor advertising interval * factor (def: 2s * X)
@@ -68,15 +67,7 @@ _attribute_ram_code_ void user_init_deepRetn(void){//after sleep this will get e
 }
 
 void main_loop(){	
-/*	if((clock_time()-last_battsym_delay) > 400*CLOCK_SYS_CLOCK_1MS){  //batt blinking delay
-	    if((battery_level < 25) && (battery_level > 15) && (!show_batt_enabled)) {
-		last_batt=!last_batt;
-		show_battery_symbol(last_batt);
-		update_lcd();
-		last_battsym_delay = clock_time();
-	    }
-	}
-*/	if((clock_time()-last_delay) > 5000*CLOCK_SYS_CLOCK_1MS){//main loop delay
+	if((clock_time()-last_delay) > 5000*CLOCK_SYS_CLOCK_1MS){//main loop delay
 	
 		if((clock_time()-last_battery_delay) > 5*60000*CLOCK_SYS_CLOCK_1MS){//Read battery delay
 			battery_mv = get_battery_mv();
@@ -110,11 +101,7 @@ void main_loop(){
 		
 		if(show_batt_or_humi){//Change between Humidity displaying and battery level if show_batt_enabled=true
 			show_small_number(last_humi,1);	
-			if(battery_level <= 15) {
-			    show_battery_symbol(1);
-			}else{
-			    show_battery_symbol(0);   
-			}
+		    show_battery_symbol(0);   
 		}else{
 			show_small_number((battery_level==100)?99:battery_level,1);
 			show_battery_symbol(1);

--- a/ATC_Thermometer/app.c
+++ b/ATC_Thermometer/app.c
@@ -18,8 +18,8 @@ RAM bool show_batt_or_humi;
 RAM bool temp_C_or_F;
 RAM bool blinking_smiley = false;
 RAM bool comfort_smiley = true;
-RAM bool show_batt_enabled = true;
-RAM bool advertising_type = false;//Custom or Mi Advertising
+RAM bool show_batt_enabled = false;
+RAM bool advertising_type = false;//Custom or Mi Advertising (true)
 RAM uint8_t advertising_interval = 6;//multiply by 10 for value
 RAM int8_t temp_offset;
 RAM int8_t humi_offset;
@@ -85,7 +85,14 @@ void main_loop(){
 		}
 		
 		
-		if(!show_batt_enabled)show_batt_or_humi = true;
+		if(!show_batt_enabled){
+			show_batt_or_humi = true;
+			if(battery_level <= 15) {
+			    show_battery_symbol(1);
+			}else{
+			    show_battery_symbol(0);
+			}
+		}
 		if(show_batt_or_humi){//Change between Humidity displaying and battery level
 			show_small_number(humi,1);	
 			show_battery_symbol(0);

--- a/ATC_Thermometer/battery.c
+++ b/ATC_Thermometer/battery.c
@@ -77,6 +77,6 @@ return batt_vol_mv;
 uint8_t get_battery_level(uint16_t battery_mv){
 	uint8_t battery_level = (battery_mv-2200)/(31-22);
 	if(battery_level>100)battery_level=100;
-	if(battery_level<0)battery_level=0;
+	if(battery_mv<2200)battery_level=0;
 	return battery_level;
 }


### PR DESCRIPTION
Insert the option to skip the wakeup of the temperature/humidity sensor for a defined time.
adv_count  will count the number of the loops in the main procedure until meas_count  was reached.

So the delay could be set to a measurement once per minute as sample instead of every loop (about every 6-7 seconds)
It will save much battery.

Additional was fixed the overflow inside the advertising time condition for now with a counter inside ;)

(the old battery fix for voltage <2200 is still inside)

PS: not sure why so much files here listed,.. I have no much experience with PR in the Github, ... have forked your project and save modifications in my Github copy. Sorry for any confusion ...