### PR TITLE
Set TEL_PATH with ?= to eliminate the need of patching the makefile

### DIFF
--- a/ATC_Thermometer/makefile
+++ b/ATC_Thermometer/makefile
@@ -2,7 +2,7 @@ TEL_CHIP := -DCHIP_TYPE=CHIP_TYPE_8258
 
 LIBS :=  -llt_8258
 
-TEL_PATH := ../..
+TEL_PATH ?= ../..
 
 PROJECT_NAME := ATC_Thermometer
 


### PR DESCRIPTION
This way the TEL_PATH could be set externally and could passed to the make without altering the makefile.

Like this:

export TEL_PATH=../../SDK make

This PR in the build env depends on this:
https://github.com/AlmightyFrog/BuildEnvironmentATCMiThermometer/pull/4
