### PR TITLE
Revert "Use enum for smiley type"

### DIFF
--- a/ATC_Thermometer/app.c
+++ b/ATC_Thermometer/app.c
@@ -131,12 +131,16 @@ void main_loop(){
 		}
 		
 		if(comfort_smiley) {
-            show_smiley(is_comfort(last_temp * 10, last_humi * 100) ? Smiley_happy : Smiley_sad);
+			if(is_comfort(last_temp * 10, last_humi * 100)){
+				show_smiley(1);
+			} else {
+				show_smiley(2);
+			}
 		}
 
 		if(blinking_smiley){//If Smiley should blink do it
-            last_smiley=!last_smiley;
-            show_smiley(last_smiley);
+		last_smiley=!last_smiley;
+		show_smiley(last_smiley);
 		}
 		
 		update_lcd();

--- a/ATC_Thermometer/ble.c
+++ b/ATC_Thermometer/ble.c
@@ -54,7 +54,7 @@ void app_enter_ota_mode(void)
 {
 	ota_is_working = 1;
 	bls_ota_setTimeout(5 * 1000000);
-	show_smiley(Smiley_happy);
+	show_smiley(1);
 }
 
 void app_switch_to_indirect_adv(uint8_t e, uint8_t *p, int n)

--- a/ATC_Thermometer/cmd_parser.c
+++ b/ATC_Thermometer/cmd_parser.c
@@ -29,15 +29,15 @@ void cmd_parser(void * p){
 	}else if(inData == 0xA0){
 		blinking_smiley = false;
 		comfort_smiley = false;
-        show_smiley(Smiley_off);
+		show_smiley(0);//Smiley off
 	}else if(inData == 0xA1){
 		blinking_smiley = false;
 		comfort_smiley = false;
-        show_smiley(Smiley_happy);
+		show_smiley(1);//Smiley happy
 	}else if(inData == 0xA2){ 
 		blinking_smiley = false;
 		comfort_smiley = false;
-        show_smiley(Smiley_sad);
+		show_smiley(2);//Smiley sad
 	}else if(inData == 0xA3){
 		blinking_smiley = false;
 		comfort_smiley = true; // Comfort Indicator
@@ -56,9 +56,9 @@ void cmd_parser(void * p){
 		if(humi_offset<-50)humi_offset=-50;
 		if(humi_offset>50)humi_offset=50;
 	}else if(inData == 0xFC){
-        //Set temp alarm point value divided by 10 for temp in °C
-        temp_alarm_point = req->dat[1] == 0 ? 1 : req->dat[1];
-    }else if(inData == 0xFD){
+		temp_alarm_point = req->dat[1];//Set temp alarm point value divided by 10 for temp in °C
+		if(temp_alarm_point==0)temp_alarm_point = 1;
+	}else if(inData == 0xFD){
 		humi_alarm_point = req->dat[1];//Set humi alarm point
 		if(humi_alarm_point==0)humi_alarm_point = 1;
 		if(humi_alarm_point>50)humi_alarm_point = 50;

--- a/ATC_Thermometer/lcd.c
+++ b/ATC_Thermometer/lcd.c
@@ -64,9 +64,10 @@ void show_battery_symbol(bool state){
 		display_buff[1] &= ~0x08;
 }
 
-void show_smiley(SmileyType_t state){
+void show_smiley(uint8_t state){/*0=off, 1=happy, 2=sad*/
 	display_buff[2] &= ~0x07;
-    display_buff[2] |= (state == Smiley_happy ? 0x05 : 0x06);
+	if(state==1)display_buff[2]|=0x05;
+	else if(state==2)display_buff[2]|=0x06;
 }
 
 void show_atc(){

--- a/ATC_Thermometer/lcd.h
+++ b/ATC_Thermometer/lcd.h
@@ -3,19 +3,13 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-typedef enum {
-    Smiley_off,
-    Smiley_happy,
-    Smiley_sad
-} SmileyType_t;
-
 void init_lcd();
 void update_lcd();
 void show_temp_symbol(uint8_t symbol);
 void show_battery_symbol(bool state);
 void show_big_number(int16_t number, bool point);
 void show_small_number(uint16_t number, bool percent);
-void show_smiley(SmileyType_t state);
+void show_smiley(uint8_t state);
 void show_atc_mac();
 void show_ble_symbol(bool state);
 void send_to_lcd_long(uint8_t byte1, uint8_t byte2, uint8_t byte3, uint8_t byte4, uint8_t byte5, uint8_t byte6);


### PR DESCRIPTION
Reverts atc1441/ATC_MiThermometer#93

Something is wrong there, it is not possible to set the Smiley to off,

just checked it but not debugged it. 